### PR TITLE
Support prefixed labels like points/3

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Project **must** have one or more labels with a description named "Story Point" 
 - `token` **(required)** GitHub repository token (`$GITHUB_TOKEN`)
 - `owner` **(required)** GitHub user or organisation.
 - `repo` **(required)** GitHub repository name.
+- `prefix` Aggregate labels that start with this prefix, like `points/3` instead of labels described as "Story Points".
 
 ## Usage
 

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
   repo:
     description: 'GitHub repository name'
     required: true
+  prefix:
+    description: 'Story point label prefix'
+    required: false
+    default: ""
 runs:
   using: 'node12'
   main: 'index.js'

--- a/action.yml
+++ b/action.yml
@@ -8,10 +8,10 @@ branding:
 inputs:
   token:
     description: 'GitHub repository token ($GITHUB_TOKEN)'
-    requried: true
+    required: true
   owner:
     description: 'GitHub user or organisation'
-    requried: true
+    required: true
   repo:
     description: 'GitHub repository name'
     required: true

--- a/index.js
+++ b/index.js
@@ -34,9 +34,11 @@ try {
                 // that prefix as indicating story points.
                 if (prefix !== "") {
                   labels.filter((l) => l.name.startsWith(prefix)).map((l) => {
-                    // TODO(negz): Handle the case where prefix is NaN?
-                    const points = l.name.slice(prefix.length)
-                    total = total + parseInt(points)
+                    const points = parseInt(l.name.slice(prefix.length))
+                    if (isNaN(points)) {
+                      return
+                    }
+                    total = total + points
                   })
                   return total
                 }
@@ -44,7 +46,11 @@ try {
                 // If a prefix was not specified we treat labels with the
                 // description 'Story Point' as indicating story points.
                 labels.filter((l) => l.description = 'Story Point').map((l) => {
-                  total = total + parseInt(l.name)
+                  const points = parseInt(l.name)
+                  if (isNaN(points)) {
+                    return
+                  }
+                  total = total + points
                 })
 
                 return total

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ try {
   const token = core.getInput('token')
   const owner = core.getInput('owner')
   const repo = core.getInput('repo')
+  const prefix = core.getInput('prefix')
 
   const payload = JSON.stringify(github.context.payload, undefined, 2)
   console.log(`The event payload: ${payload}`)
@@ -29,6 +30,19 @@ try {
               }).then(({ data: labels }) => {
                 let total = 0
 
+                // If a prefix was specified we treat all labels starting with
+                // that prefix as indicating story points.
+                if (prefix !== "") {
+                  labels.filter((l) => l.name.startsWith(prefix)).map((l) => {
+                    // TODO(negz): Handle the case where prefix is NaN?
+                    const points = l.name.slice(prefix.length)
+                    total = total + parseInt(points)
+                  })
+                  return total
+                }
+
+                // If a prefix was not specified we treat labels with the
+                // description 'Story Point' as indicating story points.
                 labels.filter((l) => l.description = 'Story Point').map((l) => {
                   total = total + parseInt(l.name)
                 })


### PR DESCRIPTION
Fixes https://github.com/mathiasjakobsen/github-estimates-action/issues/10

I've tested this out on a dummy repo and it appears to work as expected. I used the below config:

```yaml
name: Project Story Points

on:
  issues:
    types: [labeled, unlabeled, opened, closed]
  project_card:
    types: [moved, created, deleted]
  project_column:
    types: [moved, created, deleted, updated]

jobs:
  aggregate:
    runs-on: ubuntu-18.04
    steps:
      - name: Update Project Column Estimates
        uses: negz/github-estimates-action@prefix
        with:
          owner: negz
          repo: fiddle
          token: ${{ secrets.GITHUB_TOKEN }}
          prefix: 'points/
```

Dragging the below issue between the two columns results in the column titles being updated.

<img width="743" alt="pointy" src="https://user-images.githubusercontent.com/1049349/119772105-8661b980-be73-11eb-9c9e-4aa1d2e58e85.png">
